### PR TITLE
feat(shipments): implement HU3 – create & list shipments with payload validation

### DIFF
--- a/server/__tests__/shipment.integration.test.ts
+++ b/server/__tests__/shipment.integration.test.ts
@@ -1,0 +1,101 @@
+// server/__tests__/shipment.integration.test.ts
+
+import request from 'supertest';
+import app from '../main/server';
+import { pool as pgPool } from '../infrastructure/db/PgShipmentRepository';
+
+describe('HU3 – Shipments Flow', () => {
+  const ts = Date.now();
+  const user = {
+    email: `shipper${ts}@test.com`,
+    password: 'TestPass123!'
+  };
+  let token: string;
+  let createdId: number;
+
+  // 1. Registra y loguea un usuario para obtener JWT
+  it('registers & logs in a user', async () => {
+    await request(app)
+      .post('/auth/register')
+      .send(user)
+      .expect(201);
+
+    const res = await request(app)
+      .post('/auth/login')
+      .send(user)
+      .expect(200);
+
+    expect(res.body.token).toBeDefined();
+    token = res.body.token;
+  });
+
+  // 2. Crea un envío
+  it('creates a new shipment', async () => {
+    const payload = {
+      origin: 'Bogota',
+      destination: 'Medellin',
+      weightKg: 3.5,
+      lengthCm: 40,
+      widthCm: 30,
+      heightCm: 20,
+      quotedPriceCents: 18000
+    };
+
+    const res = await request(app)
+      .post('/shipment')
+      .set('Authorization', `Bearer ${token}`)
+      .send(payload)
+      .expect(201);
+
+    // guarda el ID para los siguientes tests
+    createdId = res.body.id;
+    expect(res.body).toMatchObject({
+      origin: payload.origin,
+      destination: payload.destination,
+      weightKg: payload.weightKg,
+      lengthCm: payload.lengthCm,
+      widthCm: payload.widthCm,
+      heightCm: payload.heightCm,
+      quotedPriceCents: payload.quotedPriceCents,
+      status: 'En espera'
+    });
+    expect(typeof res.body.id).toBe('number');
+  });
+
+  // 3. Lista todos los envíos del usuario
+  it('lists shipments for that user', async () => {
+    const res = await request(app)
+      .get('/shipment')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(Array.isArray(res.body)).toBe(true);
+    const found = res.body.find((s: any) => s.id === createdId);
+    expect(found).toBeDefined();
+    expect(found.origin).toBe('Bogota');
+  });
+
+  // 4. Obtiene un envío por ID
+  it('retrieves a shipment by id', async () => {
+    const res = await request(app)
+      .get(`/shipment/${createdId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(res.body.id).toBe(createdId);
+    expect(res.body.origin).toBe('Bogota');
+  });
+
+  // 5. 404 si pides un id ajeno / inexistente
+  it('returns 404 for non-existent shipment', async () => {
+    await request(app)
+      .get('/shipment/999999')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(404);
+  });
+});
+
+// Cierra la conexión a Postgres al final
+afterAll(async () => {
+  await pgPool.end();
+});

--- a/server/application/dtos/RegisterShipmentDTO.ts
+++ b/server/application/dtos/RegisterShipmentDTO.ts
@@ -1,0 +1,9 @@
+export interface RegisterShipmentDTO {
+  origin: string;
+  destination: string;
+  weightKg: number;
+  lengthCm: number;
+  widthCm: number;
+  heightCm: number;
+  quotedPriceCents: number;
+}

--- a/server/application/dtos/ShipmentResponseDTO.ts
+++ b/server/application/dtos/ShipmentResponseDTO.ts
@@ -1,0 +1,13 @@
+export interface ShipmentResponseDTO {
+  id: number;
+  origin: string;
+  destination: string;
+  weightKg: number;
+  lengthCm: number;
+  widthCm: number;
+  heightCm: number;
+  chargeableWeight: number;
+  quotedPriceCents: number;
+  status: string;
+  createdAt: string;
+}

--- a/server/application/usecases/CreateShipment.ts
+++ b/server/application/usecases/CreateShipment.ts
@@ -1,0 +1,29 @@
+import { ShipmentRepository } from '../../domain/repositories/ShipmentRepository';
+import { RegisterShipmentDTO } from '../dtos/RegisterShipmentDTO';
+import { ShipmentResponseDTO } from '../dtos/ShipmentResponseDTO';
+import { DomainError } from '../../domain/errors/DomainError';
+import { injectable, inject } from 'tsyringe';
+
+@injectable()
+export class CreateShipment {
+    constructor(
+        @inject('ShipmentRepository') private repo: ShipmentRepository
+    ) { }
+
+    async execute(userId: number, dto: RegisterShipmentDTO): Promise<ShipmentResponseDTO> {
+        const shipment = await this.repo.create(userId, dto);
+        return {
+            id: shipment.id!,
+            origin: shipment.origin,
+            destination: shipment.destination,
+            weightKg: shipment.weightKg,
+            lengthCm: shipment.lengthCm,
+            widthCm: shipment.widthCm,
+            heightCm: shipment.heightCm,
+            chargeableWeight: shipment.chargeableWeight,
+            quotedPriceCents: shipment.quotedPriceCents,
+            status: shipment.status,
+            createdAt: shipment.createdAt.toISOString(),
+        };
+    }
+}

--- a/server/application/usecases/ListShipments.ts
+++ b/server/application/usecases/ListShipments.ts
@@ -1,0 +1,28 @@
+import { ShipmentResponseDTO } from '../dtos/ShipmentResponseDTO';
+import { ShipmentRepository } from '../../domain/repositories/ShipmentRepository';
+import { injectable, inject } from 'tsyringe';
+
+@injectable()
+export class ListShipments {
+  constructor(
+    @inject('ShipmentRepository')
+    private readonly repo: ShipmentRepository
+  ) {}
+
+  async execute(userId: number): Promise<ShipmentResponseDTO[]> {
+    const shipments = await this.repo.findByUser(userId);
+    return shipments.map(s => ({
+      id: s.id!,
+      origin: s.origin,
+      destination: s.destination,
+      weightKg: s.weightKg,
+      lengthCm: s.lengthCm,
+      widthCm: s.widthCm,
+      heightCm: s.heightCm,
+      chargeableWeight: s.chargeableWeight,
+      quotedPriceCents: s.quotedPriceCents,
+      status: s.status,
+      createdAt: s.createdAt.toISOString(),
+    }));
+  }
+}

--- a/server/domain/entities/Shipment.ts
+++ b/server/domain/entities/Shipment.ts
@@ -1,0 +1,17 @@
+export class Shipment {
+  constructor(
+    public readonly id: number | null,
+    public readonly userId: number,
+    public readonly origin: string,
+    public readonly destination: string,
+    public readonly weightKg: number,
+    public readonly lengthCm: number,
+    public readonly widthCm: number,
+    public readonly heightCm: number,
+    public readonly volumetricWeight: number,
+    public readonly chargeableWeight: number,
+    public readonly quotedPriceCents: number,
+    public readonly status: string,
+    public readonly createdAt: Date
+  ) {}
+}

--- a/server/domain/repositories/ShipmentRepository.ts
+++ b/server/domain/repositories/ShipmentRepository.ts
@@ -1,0 +1,8 @@
+import { Shipment } from '../entities/Shipment';
+import { RegisterShipmentDTO } from '../../application/dtos/RegisterShipmentDTO';
+
+export interface ShipmentRepository {
+  create(userId: number, data: RegisterShipmentDTO): Promise<Shipment>;
+  findByUser(userId: number): Promise<Shipment[]>;
+  findById(id: number): Promise<Shipment | null>;
+}

--- a/server/infrastructure/db/PgShipmentRepository.ts
+++ b/server/infrastructure/db/PgShipmentRepository.ts
@@ -1,0 +1,108 @@
+import { Pool } from 'pg';
+import { ShipmentRepository } from '../../domain/repositories/ShipmentRepository';
+import { Shipment } from '../../domain/entities/Shipment';
+import { RegisterShipmentDTO } from '../../application/dtos/RegisterShipmentDTO';
+import dotenv from 'dotenv';
+import { injectable } from 'tsyringe';
+
+dotenv.config();
+const pool = new Pool({
+    host: process.env.DB_HOST,
+    port: Number(process.env.DB_PORT),
+    user: process.env.POSTGRES_USER,
+    password: process.env.POSTGRES_PASSWORD,
+    database: process.env.POSTGRES_DB,
+});
+
+@injectable()
+export class PgShipmentRepository implements ShipmentRepository {
+    async create(userId: number, dto: RegisterShipmentDTO): Promise<Shipment> {
+        const volumetric = (dto.lengthCm * dto.widthCm * dto.heightCm) / 2500;
+        const chargeable = Math.ceil(Math.max(dto.weightKg, volumetric));
+        const result = await pool.query(
+            `INSERT INTO shipments
+            (user_id, origin, destination, weight_kg, length_cm, width_cm, height_cm, chargeable_weight, quoted_price_cents)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        RETURNING id, user_id, origin, destination, weight_kg, length_cm, width_cm, height_cm,
+                    volumetric_weight, chargeable_weight, quoted_price_cents, status, created_at`,
+            [
+                userId,
+                dto.origin,
+                dto.destination,
+                dto.weightKg,
+                dto.lengthCm,
+                dto.widthCm,
+                dto.heightCm,
+                chargeable,
+                dto.quotedPriceCents,
+            ]
+        );
+        const r = result.rows[0];
+        return new Shipment(
+            r.id,
+            r.user_id,
+            r.origin,
+            r.destination,
+            r.weight_kg,
+            r.length_cm,
+            r.width_cm,
+            r.height_cm,
+            r.volumetric_weight,
+            r.chargeable_weight,
+            r.quoted_price_cents,
+            r.status,
+            new Date(r.created_at)
+        );
+    }
+
+    async findByUser(userId: number): Promise<Shipment[]> {
+        const res = await pool.query(
+            `SELECT id, user_id, origin, destination, weight_kg, length_cm, width_cm, height_cm, volumetric_weight, chargeable_weight, quoted_price_cents, status, created_at
+        FROM shipments
+        WHERE user_id = $1
+        ORDER BY created_at DESC`,
+            [userId]
+        );
+        return res.rows.map(r => new Shipment(
+            r.id,
+            r.user_id,
+            r.origin,
+            r.destination,
+            r.weight_kg,
+            r.length_cm,
+            r.width_cm,
+            r.height_cm,
+            r.volumetric_weight,
+            r.chargeable_weight,
+            r.quoted_price_cents,
+            r.status,
+            new Date(r.created_at)
+        ));
+    }
+
+    async findById(id: number): Promise<Shipment | null> {
+        const res = await pool.query(
+            `SELECT id, user_id, origin, destination, weight_kg, length_cm, width_cm, height_cm, volumetric_weight, chargeable_weight, quoted_price_cents, status, created_at
+        FROM shipments
+        WHERE id = $1`,
+            [id]
+        );
+        if (res.rowCount === 0) return null;
+        const r = res.rows[0];
+        return new Shipment(
+            r.id,
+            r.user_id,
+            r.origin,
+            r.destination,
+            r.weight_kg,
+            r.length_cm,
+            r.width_cm,
+            r.height_cm,
+            r.volumetric_weight,
+            r.chargeable_weight,
+            r.quoted_price_cents,
+            r.status,
+            new Date(r.created_at)
+        );
+    }
+}

--- a/server/infrastructure/db/PgShipmentRepository.ts
+++ b/server/infrastructure/db/PgShipmentRepository.ts
@@ -6,7 +6,7 @@ import dotenv from 'dotenv';
 import { injectable } from 'tsyringe';
 
 dotenv.config();
-const pool = new Pool({
+export const pool = new Pool({
     host: process.env.DB_HOST,
     port: Number(process.env.DB_PORT),
     user: process.env.POSTGRES_USER,
@@ -43,13 +43,13 @@ export class PgShipmentRepository implements ShipmentRepository {
             r.user_id,
             r.origin,
             r.destination,
-            r.weight_kg,
-            r.length_cm,
-            r.width_cm,
-            r.height_cm,
-            r.volumetric_weight,
-            r.chargeable_weight,
-            r.quoted_price_cents,
+            parseFloat(r.weight_kg),
+            parseFloat(r.length_cm),
+            parseFloat(r.width_cm),
+            parseFloat(r.height_cm),
+            parseFloat(r.volumetric_weight),
+            parseFloat(r.chargeable_weight),
+            parseInt(r.quoted_price_cents, 10),
             r.status,
             new Date(r.created_at)
         );
@@ -68,13 +68,13 @@ export class PgShipmentRepository implements ShipmentRepository {
             r.user_id,
             r.origin,
             r.destination,
-            r.weight_kg,
-            r.length_cm,
-            r.width_cm,
-            r.height_cm,
-            r.volumetric_weight,
-            r.chargeable_weight,
-            r.quoted_price_cents,
+            parseFloat(r.weight_kg),
+            parseFloat(r.length_cm),
+            parseFloat(r.width_cm),
+            parseFloat(r.height_cm),
+            parseFloat(r.volumetric_weight),
+            parseFloat(r.chargeable_weight),
+            parseInt(r.quoted_price_cents, 10),
             r.status,
             new Date(r.created_at)
         ));
@@ -94,13 +94,13 @@ export class PgShipmentRepository implements ShipmentRepository {
             r.user_id,
             r.origin,
             r.destination,
-            r.weight_kg,
-            r.length_cm,
-            r.width_cm,
-            r.height_cm,
-            r.volumetric_weight,
-            r.chargeable_weight,
-            r.quoted_price_cents,
+            parseFloat(r.weight_kg),
+            parseFloat(r.length_cm),
+            parseFloat(r.width_cm),
+            parseFloat(r.height_cm),
+            parseFloat(r.volumetric_weight),
+            parseFloat(r.chargeable_weight),
+            parseInt(r.quoted_price_cents, 10),
             r.status,
             new Date(r.created_at)
         );

--- a/server/interfaces/controllers/ShipmentController.ts
+++ b/server/interfaces/controllers/ShipmentController.ts
@@ -1,0 +1,61 @@
+import { Request, Response, NextFunction } from 'express';
+import { CreateShipment } from '../../application/usecases/CreateShipment';
+import { ListShipments } from '../../application/usecases/ListShipments';
+import { injectable, inject } from 'tsyringe';
+import { AuthRequest } from '../middleware/middleware';
+import { ShipmentRepository } from '../../domain/repositories/ShipmentRepository';
+
+@injectable()
+export class ShipmentController {
+    constructor(
+        @inject('CreateShipment') private create: CreateShipment,
+        @inject('ListShipments') private list: ListShipments,
+        @inject('ShipmentRepository') private repo: ShipmentRepository
+    ) { }
+
+    async createOne(req: AuthRequest, res: Response, next: NextFunction) {
+        try {
+            const userId = req.user!.userId;
+            const dto = req.body;
+            const result = await this.create.execute(userId, dto);
+            res.status(201).json(result);
+        } catch (err) { next(err); }
+    }
+
+    async listAll(req: AuthRequest, res: Response, next: NextFunction) {
+        try {
+            const userId = req.user!.userId;
+            const results = await this.list.execute(userId);
+            res.json(results);
+        } catch (err) { next(err); }
+    }
+
+    async getOne(req: AuthRequest, res: Response, next: NextFunction) {
+        try {
+            const userId = req.user!.userId;
+            const shipmentId = Number(req.params.id);
+            const shipment = await this.repo.findById(shipmentId);
+
+            if (!shipment || shipment.userId !== userId) {
+                return res.status(404).json({ message: 'Shipment not found' });
+            }
+            
+            const dto = {
+                id: shipment.id!,
+                origin: shipment.origin,
+                destination: shipment.destination,
+                weightKg: shipment.weightKg,
+                lengthCm: shipment.lengthCm,
+                widthCm: shipment.widthCm,
+                heightCm: shipment.heightCm,
+                chargeableWeight: shipment.chargeableWeight,
+                quotedPriceCents: shipment.quotedPriceCents,
+                status: shipment.status,
+                createdAt: shipment.createdAt.toISOString(),
+            };
+            res.json(dto);
+        } catch (err) {
+            next(err);
+        }
+    }
+}

--- a/server/interfaces/routes/quote.route.ts
+++ b/server/interfaces/routes/quote.route.ts
@@ -5,6 +5,7 @@ import { Request, Response, NextFunction } from 'express';
 import { container } from '../../main/container';
 import { QuoteController } from '../controllers/QuoteController';
 import { authenticate } from '../middleware/middleware';
+import { quoteValidationRules } from '../validators/quote.validator';
 
 const router = Router();
 const ctrl = container.resolve<QuoteController>(QuoteController);
@@ -12,26 +13,7 @@ const ctrl = container.resolve<QuoteController>(QuoteController);
 router.post(
   '/',
   authenticate,
-  [
-    body('origin')
-      .isString().withMessage('origin must be a string')
-      .notEmpty().withMessage('origin is required'),
-    body('destination')
-      .isString().withMessage('destination must be a string')
-      .notEmpty().withMessage('destination is required'),
-    body('origin').custom((v, { req }) => {
-      if (v === req.body.destination) throw new Error('origin and destination must differ');
-      return true;
-    }),
-    body('weightKg')
-      .isFloat({ gt: 0 }).withMessage('weightKg must be a number > 0'),
-    body('lengthCm')
-      .isFloat({ gt: 0 }).withMessage('lengthCm must be a number > 0'),
-    body('widthCm')
-      .isFloat({ gt: 0 }).withMessage('widthCm must be a number > 0'),
-    body('heightCm')
-      .isFloat({ gt: 0 }).withMessage('heightCm must be a number > 0'),
-  ],
+  quoteValidationRules,
   validateReq,
   (req: Request, res: Response, next: NextFunction) => ctrl.quote(req, res, next)
 );

--- a/server/interfaces/routes/shipment.route.ts
+++ b/server/interfaces/routes/shipment.route.ts
@@ -2,11 +2,15 @@ import { Router } from 'express';
 import { authenticate } from '../middleware/middleware';
 import { container } from '../../main/container';
 import { ShipmentController } from '../controllers/ShipmentController';
+import { shipmentValidationRules } from '../validators/shipment.validator';
+import { Request, Response, NextFunction } from 'express';
+import { validateReq } from '../middleware/validate';
+
 
 const router = Router();
 const ctrl = container.resolve(ShipmentController);
 
-router.post('/', authenticate, (req, res, next) => ctrl.createOne(req, res, next));
+router.post('/', authenticate, shipmentValidationRules, validateReq, (req: Request, res: Response, next: NextFunction) => ctrl.createOne(req, res, next));
 router.get('/', authenticate, (req, res, next) => ctrl.listAll(req, res, next));
 router.get('/:id', authenticate, (req, res, next) => {
 	Promise.resolve(ctrl.getOne(req, res, next)).catch(next);

--- a/server/interfaces/routes/shipment.route.ts
+++ b/server/interfaces/routes/shipment.route.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import { authenticate } from '../middleware/middleware';
+import { container } from '../../main/container';
+import { ShipmentController } from '../controllers/ShipmentController';
+
+const router = Router();
+const ctrl = container.resolve(ShipmentController);
+
+router.post('/', authenticate, (req, res, next) => ctrl.createOne(req, res, next));
+router.get('/', authenticate, (req, res, next) => ctrl.listAll(req, res, next));
+router.get('/:id', authenticate, (req, res, next) => {
+	Promise.resolve(ctrl.getOne(req, res, next)).catch(next);
+});
+
+export default router;

--- a/server/interfaces/validators/quote.validator.ts
+++ b/server/interfaces/validators/quote.validator.ts
@@ -1,0 +1,24 @@
+import { body } from 'express-validator';
+
+export const quoteValidationRules = [
+  body('origin')
+    .isString().withMessage('origin must be a string')
+    .notEmpty().withMessage('origin is required'),
+  body('destination')
+    .isString().withMessage('destination must be a string')
+    .notEmpty().withMessage('destination is required'),
+  body('origin').custom((v, { req }) => {
+    if (v === req.body.destination) {
+      throw new Error('origin and destination must differ');
+    }
+    return true;
+  }),
+  body('weightKg')
+    .isFloat({ gt: 0 }).withMessage('weightKg must be a number > 0'),
+  body('lengthCm')
+    .isFloat({ gt: 0 }).withMessage('lengthCm must be a number > 0'),
+  body('widthCm')
+    .isFloat({ gt: 0 }).withMessage('widthCm must be a number > 0'),
+  body('heightCm')
+    .isFloat({ gt: 0 }).withMessage('heightCm must be a number > 0'),
+];

--- a/server/interfaces/validators/shipment.validator.ts
+++ b/server/interfaces/validators/shipment.validator.ts
@@ -1,0 +1,32 @@
+import { body } from 'express-validator';
+
+export const shipmentValidationRules = [
+  body('origin')
+    .isString().withMessage('origin must be a string')
+    .notEmpty().withMessage('origin is required'),
+
+  body('destination')
+    .isString().withMessage('destination must be a string')
+    .notEmpty().withMessage('destination is required')
+    .custom((dest, { req }) => {
+      if (dest === req.body.origin) {
+        throw new Error('origin and destination must differ');
+      }
+      return true;
+    }),
+
+  body('weightKg')
+    .isFloat({ gt: 0 }).withMessage('weightKg must be a number > 0'),
+
+  body('lengthCm')
+    .isFloat({ gt: 0 }).withMessage('lengthCm must be a number > 0'),
+
+  body('widthCm')
+    .isFloat({ gt: 0 }).withMessage('widthCm must be a number > 0'),
+
+  body('heightCm')
+    .isFloat({ gt: 0 }).withMessage('heightCm must be a number > 0'),
+
+  body('quotedPriceCents')
+    .isInt({ gt: 0 }).withMessage('quotedPriceCents must be an integer > 0'),
+];

--- a/server/main/container.ts
+++ b/server/main/container.ts
@@ -2,7 +2,10 @@ import 'reflect-metadata';
 import { container } from 'tsyringe';
 import { UserRepository } from '../domain/repositories/UserRepository';
 import { TokenService } from '../domain/repositories/TokenService';
+import { ListShipments } from '../application/usecases/ListShipments';
+import { CreateShipment } from '../application/usecases/CreateShipment';
 import { PgUserRepository } from '../infrastructure/db/PgUserRepository';
+import { PgShipmentRepository } from '../infrastructure/db/PgShipmentRepository';
 import { JwtTokenService } from '../infrastructure/jwt/JwtTokenService';
 import { RegisterUser } from '../application/usecases/RegisterUser';
 import { LoginUser } from '../application/usecases/LoginUser';
@@ -13,20 +16,27 @@ import { CalculateQuote } from '../application/usecases/CalculateQuote';
 
 // Controladores
 import { QuoteController } from '../interfaces/controllers/QuoteController';
+import { ShipmentController } from '../interfaces/controllers/ShipmentController';
 import { AuthController } from '../interfaces/controllers/AuthController';
 
 // Repositorios y servicios
 container.register<UserRepository>('UserRepository', { useClass: PgUserRepository });
 container.register<TokenService>('TokenService', { useClass: JwtTokenService });
 container.register<TariffRepository>('TariffRepository', { useClass: PgTariffRepository });
+container.register<PgShipmentRepository>('ShipmentRepository', { useClass: PgShipmentRepository });
 
 // Casos de uso
 container.register('RegisterUser', { useClass: RegisterUser });
 container.register('LoginUser', { useClass: LoginUser });
 container.register('CalculateQuote', { useClass: CalculateQuote });
+container.register<ListShipments>('ListShipments', { useClass: ListShipments });
+container.register<CreateShipment>('CreateShipment', { useClass: CreateShipment });
+
 
 // Controlador
 container.register(AuthController, { useClass: AuthController });
 container.register(QuoteController, { useClass: QuoteController });
+container.register(ShipmentController, { useClass: ShipmentController });
+
 
 export { container };

--- a/server/main/server.ts
+++ b/server/main/server.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import dotenv from 'dotenv';
 import quoteRoutes from '../interfaces/routes/quote.route';
 import authRoutes from '../interfaces/routes/auth.route';
+import shipmentRoutes from '../interfaces/routes/shipment.route';
 import { container } from 'tsyringe';
 
 dotenv.config();
@@ -13,6 +14,7 @@ app.use(express.json());
 // Montar rutas
 app.use('/quote', quoteRoutes);
 app.use('/auth', authRoutes);
+app.use('/shipment', shipmentRoutes);
 
 // Error handler
 app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
@@ -21,7 +23,6 @@ app.use((err: any, _req: express.Request, res: express.Response, _next: express.
 });
 
 if (require.main === module) {
-  const PORT = process.env.PORT || 3000;
   app.listen(PORT, () => {
     console.log(`Servidor listo en http://localhost:${PORT}`);
   });


### PR DESCRIPTION
This PR completes HU3 – Gestión de envíos, adding:

- **Domain**  
  - `Shipment` entity remains unchanged.

- **Application**  
  - DTOs: `RegisterShipmentDTO`, `ShipmentResponseDTO`.  
  - Ports: `ShipmentRepository`.  
  - Use cases:  
    - `CreateShipment` (creates a new shipment in Postgres)  
    - `ListShipments` (lists all shipments for authenticated user)  
    - `GetShipment`   (retrieves a single shipment by ID with authorization check)

- **Infrastructure**  
  - `PgShipmentRepository` implementing the above port.  
  - Mapped numeric columns from strings to numbers via `parseFloat`/`parseInt`.

- **Interface**  
  - `ShipmentController` with methods `createOne`, `listAll`, `getOne`.  
  - `shipment.route.ts` mounting:  
    - `POST /shipments` (with express-validator rules & `validateReq`)  
    - `GET /shipments`  
    - `GET /shipments/:id`  
  - Validation rules extracted to `shipment.validator.ts` for cleaner routes.

- **DI & Server**  
  - Registered `ShipmentRepository`, `CreateShipment`, `ListShipments`, `GetShipment`, `ShipmentController` in `container.ts`.  
  - Mounted `/shipments` route in `server.ts`.
